### PR TITLE
using wolox-react-scripts react-scripts configuration with rewire

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -101,6 +101,11 @@ class GeneratorReact extends Generator {
         includeAll: this.includeAll
       }
     );
+    this.fs.copyTpl(
+      this.templatePath('config-overrides.js'),
+      this.destinationPath('config-overrides.js'),
+      {}
+    );
 
     // TODO remove this, and add only index from CRA (with Webpack configuration)
     this.fs.copy(

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -43,6 +43,7 @@
     "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {
+    "react-app-rewired": "^1.5.2",
     "babel-eslint": "^7.2.3",
     "eslint": "^4.6.1",
     "eslint-config-airbnb": "^15.1.0",
@@ -55,18 +56,19 @@
     "husky": "^0.14.3",
     "prettier": "^1.6.1",
     "prettier-eslint": "^8.0.0",
-    "react-scripts": "^1.0.13"
+    "react-scripts": "^1.0.13",
+    "wolox-react-scripts": "^1.2.0"
   },
   "scripts": {
-    "start": "./node_modules/react-scripts/bin/react-scripts.js start",
-    "build": "./node_modules/react-scripts/bin/react-scripts.js build",
+    "start": "react-app-rewired start --scripts-version wolox-react-scripts",
+    "build": "react-app-rewired build --scripts-version wolox-react-scripts",
     "test":
-      "./node_modules/react-scripts/bin/react-scripts.js test --env=jsdom",
+      "react-app-rewired test --scripts-version wolox-react-scripts --env=jsdom",
     "eject": "./node_modules/react-scripts/bin/react-scripts.js eject",
-    "deploy": "npm run build",
+    "deploy": "react-app-rewired build --scripts-version wolox-react-scripts",
     "lint": "./node_modules/eslint/bin/eslint.js src",
     "lint-fix": "./node_modules/eslint/bin/eslint.js src --fix",
     "lint-diff": "git diff --name-only --cached --relative | grep \\.js$ | xargs eslint",
     "precommit": "npm run lint-diff"
-  },
+  }
 }

--- a/generators/app/templates/config-overrides.js
+++ b/generators/app/templates/config-overrides.js
@@ -1,0 +1,4 @@
+module.exports = function override(config, env) {
+  //do stuff with the webpack config...
+  return config;
+}

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import App from './app';
+import App from './App';
 import './config/i18n';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "husky": "^0.14.3",
     "prettier": "^1.6.1",
     "prettier-eslint": "^8.0.0",
-    "react-scripts": "^1.0.13"
+    "react-scripts": "^1.0.13",
+    "react-app-rewired": "^1.5.2"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -27,16 +27,13 @@ elif ! system_has yarn; then
   echo "Yarn is mandatory to continue"
   echo "Check this guide to complete the installation: https://yarnpkg.com/lang/en/docs/install/#alternatives-tab"
   exit 1
-elif  [[ $PATH != *"$HOME/.yarn/bin"* ]]; then
-  echo "Yarn global bin path must be cointained inside PATH varible"
-  exit 1
 fi
 
 
 yarn global add create-react-app --prefix /usr/local > /dev/null 2>&1
 PROJECT_NAME=`echo "${PWD##*/}"`
 cd ..
-create-react-app "${PROJECT_NAME}" --scripts-version wolox-react-scripts
+create-react-app "${PROJECT_NAME}"
 yarn global add yo generator-react-bootstrap > /dev/null 2>&1
 cd $PROJECT_NAME
 yo react-bootstrap --force


### PR DESCRIPTION
## Summary

Previously, we were using create-react-app with wolox-react-scripts. I added rewire to replace the custom react scripts.

I also fixed a small bug when importing the App.js file so the project compiles after bootstrapping.

A future improvement would be move the wolox.react-scripts' custom configuration to rewires so we don't depend on a fixed react-scripts version or be forced to update wolox.react-scripts each time react-scripts updates.