### PR TITLE
Update lint-diff to ignore removed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy": "npm run build",
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "lint-fix": "./node_modules/eslint/bin/eslint.js . --fix",
-    "lint-diff": "git diff --name-only --cached --relative | grep \\.js$ | xargs ./node_modules/eslint/bin/eslint.js",
+    "lint-diff": "git diff --name-only --cached --relative --diff-filter=ACM | grep \\.js$ | xargs ./node_modules/eslint/bin/eslint.js",
     "precommit": "npm run lint"
   },
   "repository": "git+https://github.com/Wolox/react-bootstrap.git",


### PR DESCRIPTION
## Summary

- changed lint-diff script to take into account removed files

## Notes

This change will help to avoid the problem when lint-diff tries to check for a deleted file with eslint and fail.