### PR TITLE
updated to CRA 2 to fix bootstrap

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -127,8 +127,8 @@ module.exports.OPTIONAL_DEPENDENCIES = {
   'prop-types': { dependencies: ['prop-types'] },
   'seamless-immutable': { dependencies: ['seamless-immutable'] },
   flow: {
-    dependencies: ['babel-cli'],
-    devDependencies: ['flow-bin', 'babel-preset-flow']
+    dependencies: ['@babel/cli'],
+    devDependencies: ['flow-bin', '@babel/preset-flow']
   },
   reselect: { dependencies: ['reselect'] }
 };

--- a/generators/app/tasks/configPackageJson.js
+++ b/generators/app/tasks/configPackageJson.js
@@ -1,5 +1,5 @@
 const generateRARScript = (command, options) =>
-  `react-app-rewired ${command} --scripts-version wolox-react-scripts${options ? ` ${options}` : ''}`;
+  `react-app-rewired ${command} ${options ? ` ${options}` : ''}`;
 
 const getPackageJsonAttributes = (projectName, projectVersion, repoUrl, features) => {
   const attributes = {

--- a/generators/app/tasks/createReactApp.js
+++ b/generators/app/tasks/createReactApp.js
@@ -2,7 +2,7 @@ const runCommand = require('./runCommand');
 
 module.exports.installCRA = function installCRA() {
   return runCommand({
-    command: ['npm', ['install', '--global', 'create-react-app@^1.5.2']],
+    command: ['npm', ['install', '--global', 'create-react-app']],
     loadingMessage: 'Installing create-react-app',
     successMessage: 'create-react-app installed successfully',
     failureMessage: 'create-react-app installation failed',

--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -15,13 +15,12 @@ const DEPENDENCIES = [
   'react-router',
   'react-router-dom',
   'react-spinkit',
-  'wolox-equalizer'
+  'wolox-equalizer',
+  'node-sass'
 ];
 
 const DEV_DEPENDENCIES = [
   'react-app-rewired',
-  'babel-eslint',
-  'eslint',
   'eslint-config-airbnb',
   'eslint-config-prettier',
   'eslint-plugin-flowtype',
@@ -32,8 +31,6 @@ const DEV_DEPENDENCIES = [
   'husky',
   'prettier',
   'prettier-eslint',
-  'react-scripts',
-  'wolox-react-scripts',
   '@storybook/react'
 ];
 


### PR DESCRIPTION
## Summary

With CRA 2 bootstrap isn't working. So I:

- Updated to CRA 2
- Removed some dependencies clashing with internal react-scripts dependencies
- Removed react-scripts and wolox-react-scripts as dependencies
- Removed ---wolox-react-scripts flag for rewired
- Updated babel dependencies to the new scoped babel 7 packages.