### PR TITLE
css/scss modules can now be used as camelCase in JS

### DIFF
--- a/generators/app/templates/config-overrides.js
+++ b/generators/app/templates/config-overrides.js
@@ -1,4 +1,26 @@
+const path = require('path');
+
+const createLoaderMatcher = loader => rule =>
+  rule.loader && rule.loader.indexOf(`${path.sep}${loader}${path.sep}`) !== -1; //eslint-disable-line
+
+const fileLoaderMatcher = createLoaderMatcher('css-loader');
+
+const addCamelCaseToCSSModules = config => {
+  const fileLoaders = config.module.rules.find(rule => rule.oneOf).oneOf;
+
+  fileLoaders.forEach(loader => {
+    if (loader.test && loader.use) {
+      loader.use.forEach(use => {
+        if (fileLoaderMatcher(use) && use.options.modules) {
+          use.options.camelCase = true;
+        }
+      });
+    }
+  });
+};
+
 module.exports = function override(config) {
-  // Do stuff with the webpack config...
+  addCamelCaseToCSSModules(config);
+
   return config;
 };

--- a/generators/app/templates/src/app/components/RadioGroup/components/RadioOption/index.js
+++ b/generators/app/templates/src/app/components/RadioGroup/components/RadioOption/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 function RadioOption({ className, inputClassName, labelClassName, label, children, ...rest }) {
   return (
     <div className={className}>
+      {/* eslint-disable-next-line react/forbid-dom-props */}
       <input type="radio" id={label} className={inputClassName} {...rest} />
       {label && (
         <label htmlFor={label} className={labelClassName}>
@@ -16,16 +17,16 @@ function RadioOption({ className, inputClassName, labelClassName, label, childre
 }
 
 RadioOption.propTypes = {
-  className: PropTypes.string,
-  inputClassName: PropTypes.string,
-  labelClassName: PropTypes.string,
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
-  name: PropTypes.string,
-  label: PropTypes.string,
   value: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
-  children: PropTypes.node
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  inputClassName: PropTypes.string,
+  label: PropTypes.string,
+  labelClassName: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func
 };
 
 export default RadioOption;

--- a/generators/app/templates/src/app/components/RadioGroup/index.js
+++ b/generators/app/templates/src/app/components/RadioGroup/index.js
@@ -24,6 +24,7 @@ class RadioGroup extends Component {
 
   handleChange = event => {
     const { onChange } = this.props;
+
     this.setState({ selectedValue: event.target.value });
     if (onChange) {
       onChange(event);
@@ -34,6 +35,7 @@ class RadioGroup extends Component {
     const { className, name, disabled, children } = this.props;
     const { selectedValue } = this.state;
     const context = { selectedValue, name, disabled, onChange: this.handleChange };
+
     return (
       <div className={className}>
         <Provider value={context}>{children}</Provider>
@@ -49,9 +51,9 @@ RadioGroup.defaultProps = {
 
 RadioGroup.propTypes = {
   className: PropTypes.string,
-  selectedValue: PropTypes.string,
-  name: PropTypes.string,
   disabled: PropTypes.bool,
+  name: PropTypes.string,
+  selectedValue: PropTypes.string,
   onChange: PropTypes.func
 };
 


### PR DESCRIPTION
## Summary

Overrode the webpack configuration so we can import the css/scss modules as camelcase instead of snakecase. 

Also fixed some small issues with the linter

## Screenshots
Example of imported styles:
<img width="297" alt="screen shot 2018-11-06 at 10 59 07" src="https://user-images.githubusercontent.com/5349650/48070160-faed8380-e1b5-11e8-9911-739d30111288.png">
