### PR TITLE
babelrc enabled and added optional chaining plugin

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -40,6 +40,11 @@ module.exports.FLOWCONFIG_PATH = {
   destination: '.flowconfig'
 };
 
+module.exports.BABELRC_PATH = {
+  src: 'babelrc',
+  destination: '.babelrc'
+};
+
 const COMPONENTS_PATH = 'src/app/components';
 const SCREENS_PATH = 'src/app/screens';
 const CONFIG_PATH = 'src/config';

--- a/generators/app/tasks/copyTemplateFiles.js
+++ b/generators/app/tasks/copyTemplateFiles.js
@@ -6,7 +6,8 @@ const {
   TEMPLATE_FILES,
   FLOWCONFIG_PATH,
   CI_CONFIG_FILE,
-  LINTER_IGNORE_PATH
+  LINTER_IGNORE_PATH,
+  BABELRC_PATH
 } = require('../constants');
 
 const { copyTpl, copy, copyEjsTpl, deleteFiles } = require('./utils');
@@ -30,6 +31,8 @@ module.exports = function copyTemplateFiles() {
   }
 
   bindedCopy(LINTER_IGNORE_PATH.src, LINTER_IGNORE_PATH.destination);
+
+  bindedCopy(BABELRC_PATH.src, BABELRC_PATH.destination);
 
   bindedCopyTpl(CI_CONFIG_FILE, CI_CONFIG_FILE, {
     projectName: this.projectName

--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -46,7 +46,8 @@ const DEV_DEPENDENCIES = [
   'react-hot-loader',
   'react-app-rewire-wolox',
   '@storybook/react',
-  'prop-types'
+  'prop-types',
+  '@babel/plugin-proposal-optional-chaining'
 ];
 
 /**

--- a/generators/app/templates/babelrc
+++ b/generators/app/templates/babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@babel/plugin-proposal-optional-chaining"]
+}

--- a/generators/app/templates/config-overrides.js
+++ b/generators/app/templates/config-overrides.js
@@ -1,19 +1,33 @@
-// const rewireWolox = require('react-app-rewire-wolox');
+// Const rewireWolox = require('react-app-rewire-wolox');
 
 const path = require('path');
 
 const createLoaderMatcher = loader => rule =>
   rule.loader && rule.loader.indexOf(`${path.sep}${loader}${path.sep}`) !== -1; //eslint-disable-line
 
-const fileLoaderMatcher = createLoaderMatcher('css-loader');
+const oneOfFileLoaders = config => config.module.rules.find(rule => rule.oneOf).oneOf;
+
+const cssLoaderMatcher = createLoaderMatcher('css-loader');
+
+const babelLoaderMatcher = createLoaderMatcher('babel-loader');
+
+const enableBabelRc = config => {
+  const fileLoaders = oneOfFileLoaders(config);
+
+  fileLoaders.forEach(loader => {
+    if (babelLoaderMatcher(loader)) {
+      loader.options.babelrc = true;
+    }
+  });
+};
 
 const addCamelCaseToCSSModules = config => {
-  const fileLoaders = config.module.rules.find(rule => rule.oneOf).oneOf;
+  const fileLoaders = oneOfFileLoaders(config);
 
   fileLoaders.forEach(loader => {
     if (loader.test && loader.use) {
       loader.use.forEach(use => {
-        if (fileLoaderMatcher(use) && use.options.modules) {
+        if (cssLoaderMatcher(use) && use.options.modules) {
           use.options.camelCase = true;
         }
       });
@@ -23,7 +37,11 @@ const addCamelCaseToCSSModules = config => {
 
 module.exports = function override(config) {
   addCamelCaseToCSSModules(config);
-  // TODO: Soon..
-  // return rewireWolox(config, env);
+  enableBabelRc(config);
+  /*
+   * TODO: Soon..
+   * return rewireWolox(config, env);
+   */
+
   return config;
 };


### PR DESCRIPTION
## Summary

CRA 2 configuration doesn't enable the Babel config to be overriden. So I modified the webpack config to be able to use the .babelrc. This way, I could add the [optional-chaining proposal](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)

Note: I had to download the Babel JavaScript plugin for VSCode for the syntax highlighting to work properly

## Screenshots

![svl-react](https://user-images.githubusercontent.com/5349650/48138377-fd69df00-e282-11e8-8f7f-8ba26d16f98b.gif)
