### PR TITLE
Excluding deleted files from eslint

### DIFF
--- a/generators/app/tasks/configPackageJson.js
+++ b/generators/app/tasks/configPackageJson.js
@@ -17,7 +17,7 @@ const getPackageJsonAttributes = (projectName, projectVersion, repoUrl, features
       deploy: generateRARScript('build'),
       lint: './node_modules/eslint/bin/eslint.js src',
       'lint-fix': './node_modules/eslint/bin/eslint.js src --fix',
-      'lint-diff': 'git diff --name-only --cached --relative | grep \\.js$ | xargs eslint',
+      'lint-diff': 'git diff --name-only --cached --relative --diff-filter=ACM | grep \\.js$ | xargs eslint',
       precommit: 'npm run lint-diff',
       storybook: 'start-storybook -p 9001 -c .storybook'
     }


### PR DESCRIPTION
## Summary

Avoids `xargs` errors due to files not found while running linter.