### PR TITLE
Added script to automate npm-no-sudo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 wolox-react-bootstrap
 ==================
 
+This script aims to automate the process of initializing a React App using the Wolox standards.
+
 ## Prerequisites
 
 - [React](https://facebook.github.io/react/docs/getting-started.html)
@@ -10,16 +12,20 @@ wolox-react-bootstrap
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 
-## TL;DR
+## How to use
 
-You don't need to clone this repository. Just follow this steps:
+You don't need to clone this repository. Just follow these steps:
 
-1- Run the following command:
+1- Run the installation script using the following command:
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/run.sh) [--verbose]
 ```
 
-2- Search for TODO commented lines and follow the instructions. (Search "// TODO")
+2- Search for `TODO` commented lines and follow the instructions. (Search "// TODO")
 
 3- Add .env file with your API_BASE_URL
+
+## Notes
+
+This script will configure your system to install global npm packages without having to use sudo.

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,14 @@
 
 { # this ensures the entire script is downloaded #
 
+printf "\n\nThis script requires an npm configuration that allows global\n"
+printf "installs without sudo. We'll be checking whether you have globally\n"
+printf "installed packages and we'll be moving them to a new folder.\n\n"
+printf "You may have to type in your password once to allow moving all\n"
+printf "your currently installed packages.\n\n"
+
+./scripts/npm-no-sudo.sh
+
 echo "Getting initial dependencies..."
 
 system_has() {

--- a/run.sh
+++ b/run.sh
@@ -29,21 +29,12 @@ printf "You may have to type in your password once to allow moving all\n"
 printf "your currently installed packages.\n\n"
 
 if [[ $1 == '--verbose' || $1 == '-v' ]]
-then if [[ $1 == '--local' || $1 == '-l']]
 then
-  ./scripts/npm-no-sudo.sh
-else
   bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh) [--verbose]
-fi
-npm i -g yo generator-react-bootstrap
-else
-if [[ $1 == '--local' || $1 == '-l']]
-then
-  ./scripts/npm-no-sudo.sh
+  npm i -g yo generator-react-bootstrap
 else
   bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh)
-fi
-npm i -g yo generator-react-bootstrap > /dev/null 2>&1
+  npm i -g yo generator-react-bootstrap > /dev/null 2>&1
 fi
 
 if [[ $1 == '--local' || $1 == '-l' ]]

--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,6 @@
 
 { # this ensures the entire script is downloaded #
 
-printf "\n\nThis script requires an npm configuration that allows global\n"
-printf "installs without sudo. We'll be checking whether you have globally\n"
-printf "installed packages and if so, we'll be moving them to a new folder.\n\n"
-printf "You may have to type in your password once to allow moving all\n"
-printf "your currently installed packages.\n\n"
-
-./scripts/npm-no-sudo.sh
-
 echo "Getting initial dependencies..."
 
 system_has() {
@@ -25,15 +17,33 @@ if ! system_has git; then
   exit 1
 
 elif [ "$(printf '%s\n' "$requirednodeversion" "$currentnodeversion" | sort -V | head -n1)" != "$requirednodeversion" ]; then 
-  echo "The node version must be >= v6.2.0"  
+  echo "The node version must be >= v6.2.0"
   exit 1
 fi
 
+
+printf "\n\nThis script requires an npm configuration that allows global\n"
+printf "installs without sudo. We'll be checking whether you have globally\n"
+printf "installed packages and if so, we'll be moving them to a new folder.\n\n"
+printf "You may have to type in your password once to allow moving all\n"
+printf "your currently installed packages.\n\n"
+
 if [[ $1 == '--verbose' || $1 == '-v' ]]
+then if [[ $1 == '--local' || $1 == '-l']]
 then
-  npm i -g yo generator-react-bootstrap
+  ./scripts/npm-no-sudo.sh
 else
-  npm i -g yo generator-react-bootstrap > /dev/null 2>&1
+  bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh) [--verbose]
+fi
+npm i -g yo generator-react-bootstrap
+else
+if [[ $1 == '--local' || $1 == '-l']]
+then
+  ./scripts/npm-no-sudo.sh
+else
+  bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh)
+fi
+npm i -g yo generator-react-bootstrap > /dev/null 2>&1
 fi
 
 if [[ $1 == '--local' || $1 == '-l' ]]

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@
 
 printf "\n\nThis script requires an npm configuration that allows global\n"
 printf "installs without sudo. We'll be checking whether you have globally\n"
-printf "installed packages and we'll be moving them to a new folder.\n\n"
+printf "installed packages and if so, we'll be moving them to a new folder.\n\n"
 printf "You may have to type in your password once to allow moving all\n"
 printf "your currently installed packages.\n\n"
 

--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,7 @@ printf "your currently installed packages.\n\n"
 
 if [[ $1 == '--verbose' || $1 == '-v' ]]
 then
-  bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh) [--verbose]
+  curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh | bash -s -- -v
   npm i -g yo generator-react-bootstrap
 else
   bash <(curl -s https://raw.githubusercontent.com/Wolox/react-bootstrap/development/scripts/npm-no-sudo.sh)

--- a/scripts/npm-no-sudo.sh
+++ b/scripts/npm-no-sudo.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+
+usage()
+{
+cat << EOF
+usage: $0 [-d] [-v]
+This script is intended to fix the common problem where npm users
+are required to use sudo to install global packages.
+It will backup a list of your installed packages remove all but npm,
+then create a local directory, configure node to use this for global installs
+whilst also fixing permissions on the .npm dir before, reinstalling the old packages.
+OPTIONS:
+   -h   Show this message
+   -d   debug
+   -v   Verbose
+EOF
+}
+
+
+DEBUG=0
+VERBOSE=0
+while getopts "dv" OPTION
+do
+     case $OPTION in
+         d)
+             DEBUG=1
+             ;;
+         v)
+             VERBOSE=1
+             ;;
+         ?)
+             usage
+             exit
+             ;;
+     esac
+done
+
+to_reinstall='/tmp/npm-reinstall.txt'
+
+if [ 1 = ${VERBOSE} ];  then
+    printf "\nSaving list of existing global npm packages\n"
+fi
+
+#Get a list of global packages (not deps)
+#except for the npm package
+#save in a temporary file.
+npm -g list --depth=0 --parseable --long | cut -d: -f2 | grep -v '^npm@\|^$' >$to_reinstall
+
+if [ -f $NVM_DIR/nvm.sh ]; then
+    printf "Found a possible nvm install - this script may cause issues, so will exit\n"
+    printf "a list of your current node's npm packages is in $to_reinstall\n\n"
+    printf "If you save this file somewhere else, e.g. ~/npm-reinstall.txt, you can run\n\n"
+    printf "cat ~/npm-reinstall.txt | xargs npm -f install\n\n"
+    printf "when you add new node versions with nvm\n"
+    exit
+fi
+
+if [ 1 = ${VERBOSE} ];  then
+    printf "\nRemoving existing packages temporarily - you might need your sudo password\n\n"
+fi
+#List the file
+#replace the version numbers
+#remove the newlines
+#and pass to npm uninstall
+
+uninstall='sudo npm -g uninstall'
+if [ 1 = ${DEBUG} ];    then
+    printf "Won't uninstall\n\n"
+    uninstall='echo'
+fi
+if [ -s $to_reinstall ]; then
+    cat $to_reinstall | sed -e 's/@.*//' | xargs $uninstall
+fi
+
+defaultnpmdir="${HOME}/.npm-packages"
+npmdir=''
+
+read -p "Choose your install directory. Default (${defaultnpmdir}) : " npmdir
+
+if [ -z ${npmdir} ]; then
+    npmdir=${defaultnpmdir}
+else
+    if [ ! -d ${npmdir} ]; then
+        echo "${npmdir} is not a directory."
+        exit
+    fi
+    npmdir="${npmdir}/.npm-packages"
+fi
+
+if [ 1 = ${VERBOSE} ];  then
+    printf "\nMake a new directory ${npmdir} for our "-g" packages\n"
+fi
+
+if [ 0 = ${DEBUG} ];    then
+    mkdir -p ${npmdir}
+    npm config set prefix $npmdir
+fi
+
+if [ 1 = ${VERBOSE} ];  then
+    printf "\nFix permissions on the .npm directories\n"
+fi
+
+me=`whoami`
+sudo chown -R $me $npmdir
+
+if [ 1 = ${VERBOSE} ];  then
+    printf "\nReinstall packages\n\n"
+fi
+
+#list the packages to install
+#and pass to npm
+install='npm -g install'
+if [ 1 = ${DEBUG} ];    then
+    install='echo'
+fi
+if [ -s $to_reinstall ]; then
+    cat $to_reinstall | xargs $install
+fi
+
+envfix='
+export NPM_PACKAGES="%s"
+export NODE_PATH="$NPM_PACKAGES/lib/node_modules${NODE_PATH:+:$NODE_PATH}"
+export PATH="$NPM_PACKAGES/bin:$PATH"
+# Unset manpath so we can inherit from /etc/manpath via the `manpath`
+# command
+unset MANPATH  # delete if you already modified MANPATH elsewhere in your config
+export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
+'
+
+fix_env() {
+    if [ -f "${HOME}/.bashrc" ];    then
+        printf "${envfix}" ${npmdir} >> ~/.bashrc
+        printf "\nDon't forget to run 'source ~/.bashrc'\n"
+    fi
+    if [ -f "${HOME}/.zshrc" ]; then
+        printf "${envfix}" ${npmdir} >> ~/.zshrc
+        printf "\nDon't forget to run 'source ~/.zshrc'\n"
+    fi
+
+}
+
+echo_env() {
+    printf "\nYou may need to add the following to your ~/.bashrc / .zshrc file(s)\n\n"
+    printf "${envfix}\n\n" ${npmdir}
+}
+
+printf "\n\n"
+read -p "Do you wish to update your .bashrc/.zshrc file(s) with the paths and manpaths? [yn] " yn
+case $yn in
+    [Yy]* ) fix_env;;
+    [Nn]* ) echo_env;;
+    * ) printf "\nInvalid choice\n"; echo_env;;
+esac
+
+rm $to_reinstall
+
+printf "\nDone - current package list:\n\n"
+npm -g list -depth=0

--- a/scripts/npm-no-sudo.sh
+++ b/scripts/npm-no-sudo.sh
@@ -146,11 +146,15 @@ echo_env() {
 
 printf "\n\n"
 read -p "Do you wish to update your .bashrc/.zshrc file(s) with the paths and manpaths? [yn] " yn
-case $yn in
-    [Yy]* ) fix_env;;
-    [Nn]* ) echo_env;;
-    * ) printf "\nInvalid choice\n"; echo_env;;
-esac
+if [ -z $yn  ]; then
+  printf "\nInvalid choice\n"; echo_env
+elif [ $yn = "Y" || $yn = "y"]; then
+  fix_env
+elif [ $yn = "N" || $yn = "n"]; then
+  echo_env
+else
+  printf "\nInvalid choice\n"; echo_env
+fi
 
 rm $to_reinstall
 


### PR DESCRIPTION
## Summary

Added script provided by npm that will allow the system to install npm packages globally without requiring using the `sudo` command. This fixes the errors caused by attempting to install `create-react-app` globally when running this script as a standard user.