### PR TITLE
replaced rewired with rescripts

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -63,10 +63,14 @@ module.exports.FLOWCONFIG_PATH = {
   destination: '.flowconfig'
 };
 
+module.exports.RESCRIPTS_PATH = {
+  src: 'rescriptsrc.js',
+  destination: '.rescriptsrc.js'
+};
+
 module.exports.REDUX_COMPONENTS = [`${COMPONENTS_PATH}/Field/index.js`];
 
 module.exports.FILES = [
-  'config-overrides.js',
   'pull_request_template.md',
   'README.md',
   'src/index.js',

--- a/generators/app/tasks/configPackageJson.js
+++ b/generators/app/tasks/configPackageJson.js
@@ -1,4 +1,4 @@
-const generateRARScript = (command, options = '') => `react-app-rewired ${command} ${options}`;
+const generateRSScript = (command, options = '') => `rescripts ${command} ${options}`;
 
 const getPackageJsonAttributes = (projectName, projectVersion, repoUrl, features) => {
   const attributes = {
@@ -10,11 +10,11 @@ const getPackageJsonAttributes = (projectName, projectVersion, repoUrl, features
       url: repoUrl
     },
     scripts: {
-      start: generateRARScript('start'),
-      build: generateRARScript('build'),
-      test: generateRARScript('test', '--env=jsdom'),
+      start: generateRSScript('start'),
+      build: generateRSScript('build'),
+      test: generateRSScript('test', '--env=jsdom'),
       eject: './node_modules/react-scripts/bin/react-scripts.js eject',
-      deploy: generateRARScript('build'),
+      deploy: generateRSScript('build'),
       lint: './node_modules/eslint/bin/eslint.js src',
       'lint-fix': './node_modules/eslint/bin/eslint.js src --fix',
       'lint-diff': 'git diff --name-only --cached --relative --diff-filter=ACM | grep \\.js$ | xargs eslint',

--- a/generators/app/tasks/copyTemplateFiles.js
+++ b/generators/app/tasks/copyTemplateFiles.js
@@ -7,7 +7,8 @@ const {
   FLOWCONFIG_PATH,
   CI_CONFIG_FILE,
   LINTER_IGNORE_PATH,
-  BABELRC_PATH
+  BABELRC_PATH,
+  RESCRIPTS_PATH
 } = require('../constants');
 
 const { copyTpl, copy, copyEjsTpl, deleteFiles } = require('./utils');
@@ -33,6 +34,8 @@ module.exports = function copyTemplateFiles() {
   bindedCopy(LINTER_IGNORE_PATH.src, LINTER_IGNORE_PATH.destination);
 
   bindedCopy(BABELRC_PATH.src, BABELRC_PATH.destination);
+
+  bindedCopy(RESCRIPTS_PATH.src, RESCRIPTS_PATH.destination);
 
   bindedCopyTpl(CI_CONFIG_FILE, CI_CONFIG_FILE, {
     projectName: this.projectName

--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -31,7 +31,6 @@ const DEPENDENCIES = [
 ];
 
 const DEV_DEPENDENCIES = [
-  'react-app-rewired',
   'eslint-config-airbnb',
   'eslint-config-prettier',
   'eslint-plugin-flowtype',
@@ -46,10 +45,10 @@ const DEV_DEPENDENCIES = [
   'prettier',
   'prettier-eslint',
   'react-hot-loader',
-  'react-app-rewire-wolox',
   '@storybook/react',
   'prop-types',
-  '@babel/plugin-proposal-optional-chaining'
+  '@babel/plugin-proposal-optional-chaining',
+  '@rescripts/cli@^0.0.7'
 ];
 
 /**

--- a/generators/app/templates/rescriptsrc.js
+++ b/generators/app/templates/rescriptsrc.js
@@ -21,9 +21,9 @@ const enableBabelRc = config => {
   });
 };
 
-const addCamelCaseToCSSModules = (config, env) => {
+const addCamelCaseToCSSModules = config => {
   const fileLoaders = oneOfFileLoaders(config);
-  const loaderProperty = env === 'development' ? 'use' : 'loader';
+  const loaderProperty = config.mode === 'development' ? 'use' : 'loader';
 
   fileLoaders.forEach(loader => {
     if (loader.test && loader[loaderProperty] && loader[loaderProperty].constructor === Array) {
@@ -53,10 +53,12 @@ const useEslintConfig = config => {
   });
 };
 
-module.exports = function override(config, env) {
+const customConfig = config => {
   useEslintConfig(config);
-  addCamelCaseToCSSModules(config, env);
+  addCamelCaseToCSSModules(config);
   enableBabelRc(config);
 
   return config;
 };
+
+module.exports = [customConfig];


### PR DESCRIPTION
## Summary

react-app-rewired is now "lightly" maintained since CRA 2.0. As a result, after react-scripts updated to 2.1.1 and merged webpack.dev.config and webpack.prod.config into one file, react-app-rewired stopped working. We set react-scripts to 2.1.0 for the bootstrap to work, but npm claims it has a "high security vulnerability" and the fix is to update.
The react-app-rewired docs has other alternatives, and I chose [rescripts](https://github.com/rescripts/rescripts). The bootstrap works exactly the same with this package, and the changed were minimal