### PR TITLE
added build, deploy and start scripts for each env

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /generators/app/templates/eslintrc.js
+/generators/app/templates/scripts

--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -56,6 +56,7 @@ const SCSS_PATH = 'src/scss';
 const CI_PATH = '.woloxci/';
 const DOCS_README_PATH = 'docs';
 const DEPENDENCY_SPECIFIC_PATH = 'src/dependency_specific';
+const SCRIPTS_PATH = 'scripts';
 
 module.exports.FLOWCONFIG_PATH = {
   src: 'flowconfig',
@@ -80,6 +81,7 @@ module.exports.FILES = [
   'src/index.js',
   'Jenkinsfile',
   'jsconfig.json',
+  SCRIPTS_PATH,
   CI_PATH,
   CONFIG_PATH,
   CONSTANTS_PATH,

--- a/generators/app/tasks/configPackageJson.js
+++ b/generators/app/tasks/configPackageJson.js
@@ -14,11 +14,12 @@ const getPackageJsonAttributes = (projectName, projectVersion, repoUrl, features
       npm: '>= 6.9.0'
     },
     scripts: {
-      start: generateRSScript('start'),
-      build: generateRSScript('build'),
+      start: `env-cmd ./.env.development ${generateRSScript('start')}`,
+      'start-env': 'node ./scripts/start.js',
+      build: 'node ./scripts/build.js',
+      deploy: 'node ./scripts/deploy.js',
       test: generateRSScript('test', '--env=jsdom'),
       eject: './node_modules/react-scripts/bin/react-scripts.js eject',
-      deploy: generateRSScript('build'),
       lint: './node_modules/eslint/bin/eslint.js src',
       'lint-fix': './node_modules/eslint/bin/eslint.js src --fix',
       'lint-diff': 'git diff --name-only --cached --relative --diff-filter=ACM | grep \\.js$ | xargs eslint',

--- a/generators/app/tasks/createReactApp.js
+++ b/generators/app/tasks/createReactApp.js
@@ -2,7 +2,7 @@ const runCommand = require('./runCommand');
 
 module.exports.installCRA = function installCRA() {
   return runCommand({
-    command: ['npm', ['install', '--global', 'create-react-app']],
+    command: ['npm', ['install', '--global', 'create-react-app@2.1.8']],
     loadingMessage: 'Installing create-react-app',
     successMessage: 'create-react-app installed successfully',
     failureMessage: 'create-react-app installation failed',

--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -45,7 +45,11 @@ const DEV_DEPENDENCIES = [
   'prop-types@^15.6.2',
   '@babel/plugin-proposal-optional-chaining@^7.2.0',
   '@rescripts/cli@^0.0.7',
-  'eslint-plugin-babel@^5.3.0'
+  'eslint-plugin-babel@^5.3.0',
+  'env-cmd@8.0.2',
+  'aws-deploy-script-fe@0.0.4',
+  'chalk@2.4.2',
+  'minimist@1.2.0'
 ];
 
 /**

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -3,19 +3,54 @@ This project was bootstrapped with [REACT-BOOTSTRAP-WOLOX](https://github.com/Wo
 ## Screens
 
 This are the screens you can to choose for your app.
-  * [Login](docs/Login.md)
+
+- [Login](docs/Login.md)
 
 ## Components
 
 This are the components you can to choose for your app.
-  * [SearchBar](docs/SearchBar.md)
-  * [TextArea](docs/TextArea.md)
-  * [Field](docs/Field.md)
-  * [Spinner](docs/Spinner.md)
-  * [Checkbox](docs/Checkbox.md)
-  * [InputLabel](docs/InputLabel.md)
-  * [RadioGroup](docs/RadioGroup.md)
+
+- [SearchBar](docs/SearchBar.md)
+- [TextArea](docs/TextArea.md)
+- [Field](docs/Field.md)
+- [Spinner](docs/Spinner.md)
+- [Checkbox](docs/Checkbox.md)
+- [InputLabel](docs/InputLabel.md)
+- [RadioGroup](docs/RadioGroup.md)
 
 ## Base Styles
 
 [BaseStyles](docs/BaseStyles.md)
+
+## Deploy
+
+`npm run deploy environment`
+
+Where _environment_ must match with the current branch and _environment_ must have a .env file and a property in the aws.js configuration.
+
+Valid environments are _development_, _stage_ and _master_
+
+#### Example
+
+If you are in `development` branch:
+
+- `.env.development` exists
+- `aws.js` must have a `development` property with the keys for the corresponding bucket
+
+Then, run `npm run deploy development`
+
+#### Only building
+
+To only build the application in a specific env, run:
+
+`npm run build environment`
+
+#### Starting
+
+To start the server by default (development) run:
+
+`npm run start`
+
+To start a specific environment, run:
+
+`npm run start-env environment`

--- a/generators/app/templates/eslintignore
+++ b/generators/app/templates/eslintignore
@@ -1,1 +1,2 @@
 /src/serviceWorker.js
+/scripts

--- a/generators/app/templates/jsconfig.json
+++ b/generators/app/templates/jsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {
       "~app/*": ["./src/app/*"],
       "~components/*": ["./src/app/components/*"],

--- a/generators/app/templates/scripts/build.js
+++ b/generators/app/templates/scripts/build.js
@@ -1,0 +1,19 @@
+const { spawn } = require('child_process');
+
+const argv = require('minimist')(process.argv.slice(2));
+
+const { success, validateArgs } = require('./utils');
+
+const env = argv._[0];
+
+validateArgs(env);
+
+success(`Building '${env}'`);
+
+spawn(
+  `node ./node_modules/env-cmd/bin/env-cmd.js ./.env.${env} ./node_modules/@rescripts/cli/bin/rescripts.js build`,
+  {
+    stdio: 'inherit',
+    shell: true
+  }
+);

--- a/generators/app/templates/scripts/deploy.js
+++ b/generators/app/templates/scripts/deploy.js
@@ -1,0 +1,36 @@
+const { exec } = require('child_process');
+const { spawn } = require('child_process');
+
+const argv = require('minimist')(process.argv.slice(2));
+
+const { error, success, validateArgs } = require('./utils');
+
+const env = argv._[0];
+
+validateArgs(env);
+
+exec('git rev-parse --abbrev-ref HEAD', (e, stdout, stderr) => {
+  if (stderr || e) {
+    error(`Error getting current branch: ${stderr || e}`);
+    process.exit(1);
+  }
+
+  const currentBranch = stdout.trim();
+
+  if (env !== currentBranch) {
+    error(`Environment ${env} does not match current branch ${currentBranch}`);
+    process.exit(1);
+  }
+
+  const build = spawn('npm run build', [env], { stdio: 'inherit', shell: true });
+
+  build.on('close', code => {
+    if (code !== 0) {
+      error(`Failed to build with code ${code}`);
+      process.exit(1);
+    }
+
+    success(`Build successful, deploying to environment '${env}'`);
+    spawn('aws-deploy', ['--env', env], { stdio: 'inherit', shell: true });
+  });
+});

--- a/generators/app/templates/scripts/start.js
+++ b/generators/app/templates/scripts/start.js
@@ -1,0 +1,19 @@
+const { spawn } = require('child_process');
+
+const argv = require('minimist')(process.argv.slice(2));
+
+const { success, validateArgs } = require('./utils');
+
+const env = argv._[0];
+
+validateArgs(env);
+
+success(`Starting '${env}'`);
+
+spawn(
+  `./node_modules/env-cmd/bin/env-cmd.js ./.env.${env} ./node_modules/@rescripts/cli/bin/rescripts.js start`,
+  {
+    stdio: 'inherit',
+    shell: true
+  }
+);

--- a/generators/app/templates/scripts/utils.js
+++ b/generators/app/templates/scripts/utils.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+
+const chalk = require('chalk');
+
+const error = errorString => console.error(chalk.red(errorString));
+const success = successString => console.log(chalk.green(successString));
+
+const VALID_ENVS = ['development', 'stage', 'master'];
+
+module.exports.validateArgs = env => {
+  if (!VALID_ENVS.includes(env)) {
+    error(`Environment ${env} is not a valid environment. Valid environments are '${VALID_ENVS.join(', ')}'`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(`./.env.${env}`)) {
+    error(`.env.${env} file doesn't exist in the root directory`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync('aws.js')) {
+    error("aws.js file doesn't exist in the root directory");
+    process.exit(1);
+  }
+};
+
+module.exports.error = error;
+module.exports.success = success;


### PR DESCRIPTION
## Summary

Added scripts to validate the presence of the correct `.env`s when building and deploying. Initially, there are 3 possible environments: `development`, `stage` and `master`. The only way to deploy one of them is to be in a branch with the same name as the environment, and to have a `.env` for that environment. The scripts fails when one of these conditions isn't met, explaining the errors.

If any project needs a variation of these (like more envs or countries) the scripts should be changed to handle that. But it's a good start to avoid bad usage (or no usage) of `.env`s

Scripts added:
- start-env (to start any environment passing it as the first parameter, e.g. `npm run start-env stage`
- build
- deploy

## Screenshots

Some examples of the build failing:

<img width="725" alt="Screen Shot 2019-05-06 at 16 46 38" src="https://user-images.githubusercontent.com/5349650/57250884-e41dd180-701e-11e9-93dd-7d32367e11c1.png">
<img width="739" alt="Screen Shot 2019-05-06 at 16 46 50" src="https://user-images.githubusercontent.com/5349650/57250885-e41dd180-701e-11e9-8712-18f72092e702.png">
<img width="729" alt="Screen Shot 2019-05-06 at 16 47 02" src="https://user-images.githubusercontent.com/5349650/57250886-e41dd180-701e-11e9-907c-f6c953e731a8.png">
