### PR TITLE
removed jest as it comes with CRA 3 and fixed an app.scss bug

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -123,7 +123,6 @@ module.exports.FILES_TO_DELETE = [
 module.exports.CI_CONFIG_FILE = `${CI_PATH}/config.yml`;
 
 module.exports.OPTIONAL_DEPENDENCIES = {
-  jest: { dependencies: ['jest@^23.6.0'] },
   moment: { dependencies: ['moment@^2.23.0'] },
   'seamless-immutable': { dependencies: ['seamless-immutable@^7.1.4'] },
   flow: {

--- a/generators/app/tasks/createReactApp.js
+++ b/generators/app/tasks/createReactApp.js
@@ -2,7 +2,7 @@ const runCommand = require('./runCommand');
 
 module.exports.installCRA = function installCRA() {
   return runCommand({
-    command: ['npm', ['install', '--global', 'create-react-app@2.1.8']],
+    command: ['npm', ['install', '--global', 'create-react-app']],
     loadingMessage: 'Installing create-react-app',
     successMessage: 'create-react-app installed successfully',
     failureMessage: 'create-react-app installation failed',

--- a/generators/app/templates/src/scss/margins.scss
+++ b/generators/app/templates/src/scss/margins.scss
@@ -2,6 +2,9 @@
 $breakpoint-tablet: 768px;
 $breakpoint-desktop: 1024px;
 
+$bt-scale: null;
+$bd-scale: null;
+
 @media (max-width: $breakpoint-tablet) {
   $bt-scale: 5;
 }


### PR DESCRIPTION
## Summary

The following changes were made to make CRA 3 work:

- Removed jest as an optional dependency. It's installed with react-scripts, and `npm start` fails if the version doesn't match with the one in react-scripts
- Removed the version limitation from CRA installation
- Fixed an issue with layout.scss

