### PR TITLE
Google Analytics

### DIFF
--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -39,7 +39,7 @@ module.exports.MAIN_PROMPTS = [
     when: values => values.ga,
     type: 'input',
     name: 'gaID',
-    message: 'Enter your Google Analytics ID (leave blank to add it later)',
+    message: 'Enter Google Analytics tracking ID (or press ENTER to add it later)',
     default: 'UA-XXXXX-Y'
   },
   {

--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -30,6 +30,19 @@ module.exports.MAIN_PROMPTS = [
         : `${val} is not a valid url. Please enter a valid one.`
   },
   {
+    type: 'confirm',
+    name: 'ga',
+    message: 'Add Google Analytics?',
+    required: true
+  },
+  {
+    when: values => values.ga,
+    type: 'input',
+    name: 'gaID',
+    message: 'Enter your Google Analytics ID (leave blank to add it later)',
+    default: 'UA-XXXXX-Y'
+  },
+  {
     type: 'list',
     name: 'customized',
     message: 'Which type of bootstrap do you want?',

--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -33,14 +33,8 @@ module.exports.MAIN_PROMPTS = [
     type: 'confirm',
     name: 'ga',
     message: 'Add Google Analytics?',
-    required: true
-  },
-  {
-    when: values => values.ga,
-    type: 'input',
-    name: 'gaID',
-    message: 'Enter Google Analytics tracking ID (or press ENTER to add it later)',
-    default: 'UA-XXXXX-Y'
+    required: true,
+    suffix: ' config REACT_APP_GA_TRACK_ID env variable'
   },
   {
     type: 'list',

--- a/generators/app/tasks/copyFiles.js
+++ b/generators/app/tasks/copyFiles.js
@@ -14,7 +14,6 @@ module.exports = function copyAllFiles() {
 
   bindedCopyTpl('public/_index.html', 'public/index.html', {
     title: this.projectName,
-    ga: this.ga,
-    gaID: this.gaID
+    ga: this.ga
   });
 };

--- a/generators/app/tasks/copyFiles.js
+++ b/generators/app/tasks/copyFiles.js
@@ -13,6 +13,8 @@ module.exports = function copyAllFiles() {
   });
 
   bindedCopyTpl('public/_index.html', 'public/index.html', {
-    title: this.projectName
+    title: this.projectName,
+    ga: this.ga,
+    gaID: this.gaID
   });
 };

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -54,3 +54,12 @@ To start the server by default (development) run:
 To start a specific environment, run:
 
 `npm run start-env environment`
+
+## Google Analytics
+
+If you chose to add Google Analytics script to your project, then you need to configure the tracking ID. Set it adding `REACT_APP_GA_TRACK_ID` environment variable and the corresponding ID as value.
+
+```
+// .env.development
+REACT_APP_GA_TRACK_ID=AU-9999999-1
+```

--- a/generators/app/templates/public/_index.html
+++ b/generators/app/templates/public/_index.html
@@ -5,7 +5,19 @@
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1">
   <meta charset="utf-8">
+  <% if (ga) { %>
+  <!-- Google Analytics -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+    ga('create',  '<%= gaID %>' , 'auto');
+    ga('send', 'pageview');
+  </script>
+  <!-- End Google Analytics -->
+  <% } %>
   <title> <%= title %> </title>
 </head>
 

--- a/generators/app/templates/public/_index.html
+++ b/generators/app/templates/public/_index.html
@@ -13,7 +13,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create',  '<%= gaID %>' , 'auto');
+    ga('create',  '%REACT_APP_GA_TRACK_ID%' , 'auto');
     ga('send', 'pageview');
   </script>
   <!-- End Google Analytics -->


### PR DESCRIPTION
* add ga option into generator
* add ga script to index.html template

## Summary

Add Google Analytics script optionally, depending on user choice.
The generator prompts if `ga` should be added or not. If so, asks for the corresponding ID.

*Set the `REACT_APP_GA_TRACK_ID` environment variable in the corresponding .env*

## Screenshots

| | Screen |
|:--:|:--:|
| __Menu__ | ![image](https://user-images.githubusercontent.com/7310056/77663984-74794380-6f5c-11ea-9c24-2ffa09e5eb04.png) |
| __Result__ | ![image](https://user-images.githubusercontent.com/7310056/77665824-ece10400-6f5e-11ea-95c9-7523b8769025.png) |
| __.env__ | ![image](https://user-images.githubusercontent.com/7310056/77666154-582ad600-6f5f-11ea-976e-ba35ef6636ef.png) |
| __App running__ | ![image](https://user-images.githubusercontent.com/7310056/77666237-78f32b80-6f5f-11ea-88b3-63dd60c3c0cb.png) |