### PR TITLE
HOC Fix (withProvider) 

### DIFF
--- a/generators/app/templates/src/app/components/ProviderWrapper/index.tsx
+++ b/generators/app/templates/src/app/components/ProviderWrapper/index.tsx
@@ -1,14 +1,20 @@
 import React, { useReducer } from 'react';
 
-interface Props<U extends {}> {
+interface ActionType {
+  type: string;
+}
+
+interface Props<U extends {}, V> {
   Context: React.Context<any>;
-  reducer: React.Reducer<U, { type: string }>;
+  reducer: React.Reducer<U, V>;
   initialState: U;
 }
 
-const withProvider = <T extends {}, U>({ Context, reducer, initialState }: Props<U>) => (
-  WrappedComponent: React.ComponentType<T>
-) => {
+const withProvider = <T extends {}, U, V extends ActionType>({
+  Context,
+  reducer,
+  initialState
+}: Props<U, V>) => (WrappedComponent: React.ComponentType<T>) => {
   function ProviderWrapper(props: T) {
     const [state, dispatch] = useReducer(reducer, initialState);
     return (


### PR DESCRIPTION
## Summary

Modified typing in `withProvider` HOC.  

The main reason to do this is because of an incompatibility when passing a reducer to the HOC. Specifically, because of the action type described in what our function expects as a reducer. The following code will throw an error: 

```ts 
interface Props<U extends {}> {
  Context: React.Context<any>;
  React.Reducer<U, { type: string }>
  initialState: U;
}
```

That code means that the `withProvider` will expect a function with the following signature (for example): 

```ts
const reducer = (state: SomeState, actions: { type: string }) => SomeState
```

So, when trying to pass a reducer where the actions are of type string literals TS it's not able to reconcile the types. That's because we are not trying to assign a literal to a string type, we are telling TS that we want a function that can receive any strings not just a specific group of strings (literals).

Therefore, we find ourselves with an error, which makes sense, since the actions that are generally dispatched in several projects will be string literals. So even when literals extend from strings our function/reducer should expect a string not a literal (According to the previous reducer interface). Therefore, the solution is to extend that interface to make it flexible.

Error found: 

![image](https://user-images.githubusercontent.com/36488701/80041156-17789b00-84d2-11ea-9708-74ce79579fe7.png)

Solution: 

```ts
interface Props<U extends {}, V> {
  Context: React.Context<any>;
  reducer: React.Reducer<U, V>;
  initialState: U;
}
```

Where V extends from `ActionTypes`: 

```ts
interface ActionType {
  type: string;
}
```