### PR TITLE
Add Immer for immutable store

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -130,5 +130,6 @@ module.exports.DEPENDENCIES = [
   'react@^16.6.3',
   'react-dom@^16.6.3',
   'wolox-equalizer@^0.0.3',
-  'node-sass@^4.11.0'
+  'node-sass@^4.11.0',
+  'immer@^7.0.5'
 ];

--- a/generators/app/templates/src/app/contexts/UserContext/reducer.ts
+++ b/generators/app/templates/src/app/contexts/UserContext/reducer.ts
@@ -1,3 +1,5 @@
+import produce from 'immer';
+
 import { Nullable } from '~utils/types';
 
 export interface User {
@@ -52,16 +54,18 @@ export const actionCreators = {
   logout: (): Logout => ({ type: ActionTypes.LOGOUT })
 };
 
-export const reducer = (state: UserState, action: Action): UserState => {
-  switch (action.type) {
-    case 'SET_USER': {
-      return { ...state, user: action.payload };
-    }
-    case 'RESET_USER': {
-      return { ...state, user: null };
-    }
-    default: {
-      return state;
+export const reducer = produce(
+  (state: UserState, action: Action): UserState => {
+    switch (action.type) {
+      case 'SET_USER': {
+        return { ...state, user: action.payload };
+      }
+      case 'RESET_USER': {
+        return { ...state, user: null };
+      }
+      default: {
+        return state;
+      }
     }
   }
-};
+);

--- a/generators/app/templates/src/app/screens/Dashboard/screens/Home/reducer.ts
+++ b/generators/app/templates/src/app/screens/Dashboard/screens/Home/reducer.ts
@@ -1,3 +1,5 @@
+import produce from 'immer';
+
 export interface HomeState {
   foo: string;
 }
@@ -27,16 +29,18 @@ export const actionCreators = {
   resetFoo: (): ResetFoo => ({ type: ActionTypes.RESET_FOO })
 };
 
-export const reducer = (state: HomeState, action: Action): HomeState => {
-  switch (action.type) {
-    case ActionTypes.SET_FOO: {
-      return { ...state, foo: action.payload };
-    }
-    case ActionTypes.RESET_FOO: {
-      return { ...state, foo: '' };
-    }
-    default: {
-      return state;
+export const reducer = produce(
+  (state: HomeState, action: Action): HomeState => {
+    switch (action.type) {
+      case ActionTypes.SET_FOO: {
+        return { ...state, foo: action.payload };
+      }
+      case ActionTypes.RESET_FOO: {
+        return { ...state, foo: '' };
+      }
+      default: {
+        return state;
+      }
     }
   }
-};
+);


### PR DESCRIPTION
## Summary

Add Immer dependency and adjust reducers.

#### Why <u>not</u> ImmutableJs

* New data types and api to learn.
* Not backward-compatible with plain JavaScript syntax.
* Occasionally abuse of `asMutable`.

#### Why Immer?

* Easier to use, no new data types nor api, just plain javascript.
* If you forget that React doesn't like mutating data, Immer takes care of that for you.
`state.item = newItem` will work ok.
* [More](https://immerjs.github.io/immer/docs/introduction#benefits)

#### Links
[Immer docs](https://immerjs.github.io/immer/docs/introduction)
[Immutability the easy way](https://medium.com/hackernoon/introducing-immer-immutability-the-easy-way-9d73d8f71cb3)
[ImmutbleJs alternatives](https://medium.com/better-programming/try-these-instead-of-using-immutable-js-with-redux-f5bc3bd30190)


